### PR TITLE
Fixes GraphQl street validation tests failure on composer magento version

### DIFF
--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/SetShippingAddressOnCartTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/SetShippingAddressOnCartTest.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\GraphQl\Quote\Guest;
 
+use Magento\Customer\Api\AddressMetadataInterface;
 use Magento\GraphQl\Quote\GetMaskedQuoteIdByReservedOrderId;
 use Magento\TestFramework\Helper\Bootstrap;
 use Magento\TestFramework\TestCase\GraphQlAbstract;
@@ -21,10 +22,16 @@ class SetShippingAddressOnCartTest extends GraphQlAbstract
      */
     private $getMaskedQuoteIdByReservedOrderId;
 
+    /**
+     * @var AddressMetadataInterface
+     */
+    private $addressMetadata;
+
     protected function setUp(): void
     {
         $objectManager = Bootstrap::getObjectManager();
         $this->getMaskedQuoteIdByReservedOrderId = $objectManager->get(GetMaskedQuoteIdByReservedOrderId::class);
+        $this->addressMetadata = Bootstrap::getObjectManager()->get(AddressMetadataInterface::class);
     }
 
     /**
@@ -218,6 +225,8 @@ QUERY;
      */
     public function testSetNewShippingAddressOnCartWithRedundantStreetLine()
     {
+        $streetLineCount = $this->addressMetadata->getAttributeMetadata('street')->getMultilineCount();
+        $street = implode('","', array_fill(0, $streetLineCount + 1, 'Line'));
         $maskedQuoteId = $this->getMaskedQuoteIdByReservedOrderId->execute('test_quote');
 
         $query = <<<QUERY
@@ -231,7 +240,7 @@ mutation {
             firstname: "test firstname"
             lastname: "test lastname"
             company: "test company"
-            street: ["test street 1", "test street 2", "test street 3"]
+            street: ["{$street}"]
             city: "test city"
             region: "AL"
             postcode: "887766"
@@ -250,7 +259,7 @@ mutation {
   }
 }
 QUERY;
-        self::expectExceptionMessage('"Street Address" cannot contain more than 2 lines.');
+        self::expectExceptionMessage('"Street Address" cannot contain more than ' . $streetLineCount . ' lines.');
         $this->graphQlMutation($query);
     }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Module amazon-pay sets multiline_count street attribute value to 3 and validation doesn't throw an expected exception
### Related Pull Requests
<!-- related pull request placeholder -->
MC-40032: Magento 2.4.2-beta Automate Test Analysis
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. No issues created

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
No manual testing required
### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
